### PR TITLE
Client refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [BREAKING] Rename `linear_gradient!` to `linearGradient!` for consistency with the other svg macros (same with `radial_gradient!` and `mesh_gradient!`) (#377).
 - Fixed `base_path` with a trailing slash parsing / handling.
 - Fixed `C` macro memory / WASM file size issue.
-- Added examples `component_builder`, `i18n` and `unsaved_changes` (#459).
+- Added examples `jwt`, `component_builder`, `i18n` and `unsaved_changes` (#459).
 - Fixed `UrlRequested` handling (#459).
 - [BREAKING] Hidden and renamed module `effects` to `effect`.
 - Added `App::update_with_option`.

--- a/examples/jwt/Makefile.toml
+++ b/examples/jwt/Makefile.toml
@@ -1,19 +1,69 @@
-# ---- START ----
+extend = "../../Makefile.toml"
 
-[tasks.start_server]
-description = "Build and start Tide auth server on port 8000"
+# ---- BUILD ----
+
+[tasks.build]
+description = "Build client and server"
+clear = true
+workspace = false
+dependencies = ["build_client", "build_server"]
+
+[tasks.build_release]
+extend = "build"
+description = "Build client and server in release mode"
+dependencies = ["build_client_release", "build_server_release"]
+
+[tasks.build_client]
+description = "Build client"
+workspace = false
+install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V" }
+command = "wasm-pack"
+args = ["build", "client", "--target", "web", "--out-name", "package", "--dev"]
+
+[tasks.build_client_release]
+extend = "build_client"
+description = "Build client in release mode"
+args = ["build", "client", "--target", "web", "--out-name", "package", "--release"]
+
+[tasks.build_server]
+description = "Build server"
 workspace = false
 command = "cargo"
-args = ["run", "--package", "auth_server"]
-dependencies = ["build"]
+args = ["build", "--package", "auth_server"]
 
-[tasks.start_client]
-description = "Start SPA server"
+[tasks.build_server_release]
+extend = "build_server"
+description = "Build server in release mode"
+args = ["build", "--package", "auth_server", "--release"]
+
+# ---- START ----
+
+[tasks.start]
+description = "Build and start microserver"
 workspace = false
 install_crate = { crate_name = "microserver", binary = "microserver", test_arg = "-h" }
 command = "microserver"
-args = ["--port", "8000", "--spa-index", "client/index.html"]
-dependencies = ["build"]
+args = ["--port", "8000", "client"]
+dependencies = ["build_client"]
+
+[tasks.start_release]
+extend = "start"
+description = "Build and start microserver in release mode"
+dependencies = ["build_client_release"]
+
+[tasks.start_server]
+description = "Build and start Tide auth server on port 8081"
+workspace = false
+command = "cargo"
+args = ["run", "--package", "auth_server"]
+dependencies = ["build_server"]
+
+[tasks.start_server_release]
+description = "Build and start Tide auth server on port 8081 in release mode"
+workspace = false
+command = "cargo"
+args = ["run", "--package", "auth_server", "--release"]
+dependencies = ["build_server_release"]
 
 # ---- LINT ----
 

--- a/examples/jwt/README.md
+++ b/examples/jwt/README.md
@@ -19,7 +19,7 @@ cargo make start_server
 ```
 And in another terminal
 ```bash
-cargo make start_client
+cargo make start
 ```
 
 

--- a/examples/jwt/auth_server/Cargo.toml
+++ b/examples/jwt/auth_server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 tide = "0.11"
 async-std = { version = "1.6", features = ["attributes"] }
-jsonwebtoken = "7.1"
+jsonwebtoken = "7.2"
 serde = { version = "1.0", features = ["derive"] }
 chrono = "0.4"
 time = "0.2"

--- a/examples/jwt/auth_server/Makefile.toml
+++ b/examples/jwt/auth_server/Makefile.toml
@@ -1,6 +1,0 @@
-# ---- BUILD ----
-
-[tasks.build]
-description = "Build auth server"
-command = "cargo"
-args = ["build"]

--- a/examples/jwt/auth_server/src/main.rs
+++ b/examples/jwt/auth_server/src/main.rs
@@ -73,19 +73,16 @@ async fn sign_out(_: Request<()>) -> tide::Result<Response> {
 }
 
 // Checks if a user is signed in.
-async fn signed_in(req: Request<()>) -> tide::Result<Response> {
-    let user = req.cookie("login").and_then(|cookie| {
+async fn signed_in(request: Request<()>) -> tide::Result<Response> {
+    let user = request.cookie("login").and_then(|cookie| {
         Claims::decode_token(cookie.value())
             .map(|token| token.claims.sub)
             .ok()
     });
 
-    let mut res = Response::new(StatusCode::Ok);
-    res.set_body(Body::from_json(&match user {
-        Some(_user) => true,
-        None => false,
-    })?);
-    Ok(res)
+    let mut response = Response::new(StatusCode::Ok);
+    response.set_body(Body::from_json(&user.is_some())?);
+    Ok(response)
 }
 
 // `Claims` is the data we are going to encode in our tokens.

--- a/examples/jwt/client/Makefile.toml
+++ b/examples/jwt/client/Makefile.toml
@@ -1,7 +1,0 @@
-# ---- BUILD ----
-
-[tasks.build]
-description = "Build client"
-install_crate = { crate_name = "wasm-pack", binary = "wasm-pack", test_arg = "-V" }
-command = "wasm-pack"
-args = ["build", "--target", "web", "--out-name", "package", "--dev"]

--- a/examples/jwt/client/index.html
+++ b/examples/jwt/client/index.html
@@ -12,8 +12,8 @@
   <body>
     <section id="app"></section>
     <script type="module">
-      import init from "/client/pkg/package.js";
-      init("/client/pkg/package_bg.wasm");
+      import init from "/pkg/package.js";
+      init("/pkg/package_bg.wasm");
     </script>
   </body>
 </html>

--- a/examples/jwt/client/src/lib.rs
+++ b/examples/jwt/client/src/lib.rs
@@ -1,5 +1,4 @@
 use seed::{prelude::*, *};
-use web_sys::RequestCredentials;
 
 const AUTH_SERVER: &str = "http://localhost:8081";
 
@@ -7,81 +6,89 @@ const AUTH_SERVER: &str = "http://localhost:8081";
 //     Init
 // ------ ------
 
-// `init` describes what should happen when our app starts.
 fn init(_: Url, orders: &mut impl Orders<Msg>) -> Model {
-    // Lets "order" our sign in status to be fetched.
-    orders.send_msg(Msg::FetchIsSignedIn);
-    Model::default()
+    orders.perform_cmd(async { Msg::LoginStatusFetched(fetch_login_status().await) });
+
+    Model {
+        login_status: LoginStatus::Fetching,
+    }
+}
+
+async fn fetch_login_status() -> LoginStatus {
+    let fetch_login_status = async {
+        Request::new(&format!("{}/signed-in", AUTH_SERVER))
+            // We have to allow cookies to be sent.
+            .credentials(web_sys::RequestCredentials::Include)
+            .fetch()
+            .await?
+            .json::<bool>()
+            .await
+    };
+
+    match fetch_login_status.await {
+        Ok(true) => LoginStatus::LoggedIn,
+        Ok(false) => LoginStatus::NotLoggedIn,
+        Err(fetch_error) => {
+            log!(fetch_error);
+            LoginStatus::FetchFailed(fetch_error)
+        }
+    }
 }
 
 // ------ ------
 //     Model
 // ------ ------
 
-// We are only interested in storing the login status of our user so lets set the Model
-// to a type alias.
-type Model = Option<Result<bool, FetchError>>;
+struct Model {
+    login_status: LoginStatus,
+}
+
+enum LoginStatus {
+    LoggedIn,
+    NotLoggedIn,
+    Fetching,
+    FetchFailed(FetchError),
+}
 
 // ------ ------
 //    Update
 // ------ ------
 
 enum Msg {
-    FetchIsSignedIn,
-    IsSignedInFetched(Result<bool, FetchError>),
+    LoginStatusFetched(LoginStatus),
 }
 
-// `update` describes how to handle each `Msg`.
-fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
+fn update(msg: Msg, model: &mut Model, _: &mut impl Orders<Msg>) {
     match msg {
-        Msg::FetchIsSignedIn => {
-            // `perform_cmd` allows us to get a `Msg` from an `async` function.
-            orders.perform_cmd(async { Msg::IsSignedInFetched(fetch_signed_in().await) });
-            orders.skip();
-        }
-        // Once we have the data lets attach it to the model.
-        Msg::IsSignedInFetched(data) => *model = Some(data),
+        Msg::LoginStatusFetched(login_status) => model.login_status = login_status,
     }
-}
-
-async fn fetch_signed_in() -> Result<bool, FetchError> {
-    Request::new(&format!("{}/signed-in", AUTH_SERVER))
-        // We have to allow cookies to be sent.
-        .credentials(RequestCredentials::Include)
-        .fetch()
-        .await?
-        .json()
-        .await
 }
 
 // ------ ------
 //     View
 // ------ ------
 
-// (Remove the line below once your `Model` become more complex.)
-#[allow(clippy::trivially_copy_pass_by_ref)]
-// `view` describes what to display.
 fn view(model: &Model) -> Node<Msg> {
     div![
         p![
-            "Use this link to toggle your login state. ",
-            "Close the tab and come back. Note the state should be saved."
+            "Use this link to toggle your login status. ",
+            "Close the tab and come back. Note the status should be saved."
         ],
-        match model {
-            Some(Ok(true)) => {
+        match model.login_status {
+            LoginStatus::LoggedIn => {
                 a![
                     "Sign Out",
-                    attrs! {At::Href => format!("{}/sign-out",AUTH_SERVER)}
+                    attrs! {At::Href => format!("{}/sign-out", AUTH_SERVER)}
                 ]
             }
-            Some(Ok(false)) => {
+            LoginStatus::NotLoggedIn => {
                 a![
                     "Sign In",
-                    attrs! {At::Href => format!("{}/sign-in",AUTH_SERVER)}
+                    attrs! {At::Href => format!("{}/sign-in", AUTH_SERVER)}
                 ]
             }
-            Some(Err(_)) => p!["Failed to fetch login status"],
-            None => p!["Loading"],
+            LoginStatus::FetchFailed(_) => p!["Failed to fetch login status"],
+            LoginStatus::Fetching => p!["Loading"],
         }
     ]
 }
@@ -90,7 +97,6 @@ fn view(model: &Model) -> Node<Msg> {
 //     Start
 // ------ ------
 
-// (This function is invoked by `init` function in `index.html`.)
 #[wasm_bindgen(start)]
 pub fn start() {
     App::start("app", init, update, view);

--- a/examples/jwt/client/src/lib.rs
+++ b/examples/jwt/client/src/lib.rs
@@ -1,7 +1,4 @@
-#![allow(clippy::wildcard_imports)]
-
 use seed::{prelude::*, *};
-use serde::{Deserialize, Serialize};
 use web_sys::RequestCredentials;
 
 const AUTH_SERVER: &str = "http://localhost:8081";


### PR DESCRIPTION
I wasn't able to compile and run it - I've rewritten Makefiles and deleted extra ones.

You should be able to run `cargo make start jwt` and `cargo make start_server jwt` from the Seed root or just `cargo make start` and `cargo make start` from the jwt example folder now. (`start_client` has been renamed to `start` to match other examples). And I've also added release tasks.

I've refactored client because `type Model = Option<Result<bool, FetchError>>;` is not idiomatic or expressive enough. 
I haven't looked at the server yet, except fixing come clippy warnings (please run `cargo make verify` before push).

See individual commits for more info.